### PR TITLE
Use dot nottation on query results'

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ $response = $client->travel()->delete('bba0b42e4699');
 
 The query builder provides a variety of method helping you filter your entities.
 
+#### Dot nottation
+When your are retrieving your query results. You can access them by using
+dot nottation.
+
+Eg.:
+```php
+$travels = $client->travel()->query()->filter('title')->contains('kenya')->get();
+
+//The the first name for the resposible user
+$travels->get('records.0.responsibleUser.firstname');
+```
+
 #### Filter
 Let's say that you wan't to filter your **travels** and get only records which contain the 
 word "kenya".

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
+        "adbario/php-dot-notation": "^2.2",
         "guzzlehttp/guzzle": "^7.3"
     },
     "require-dev": {

--- a/src/Clients/ReadClient.php
+++ b/src/Clients/ReadClient.php
@@ -9,8 +9,7 @@ use Tourware\Contracts\QueryBuilder;
 use Tourware\Contracts\ReadClient as ReadClientInterface;
 use Tourware\QueryBuilder as TourwareQueryBuilder;
 use Tourware\Shared\ReadRequests;
-    use GuzzleHttp\Client as Http;
-    use Psr\Http\Message\RequestInterface;
+use GuzzleHttp\Client as Http;
 use Tourware\Shared\SendRequest;
 
 class ReadClient implements ReadClientInterface
@@ -28,22 +27,22 @@ class ReadClient implements ReadClientInterface
         $this->entity = $entity;
     }
 
-    public function find(string $identifier): array
+    public function find(string $identifier): ?array
     {
         $request = $this->showRequest($identifier);
 
         $json = $this->sendRequest($request);
 
-        return (isset($json['records']) && isset($json['records'][0])) ? $json['records'][0] : [];
+        return $json->get('records.0');
     }
 
-    public function list(int $offset = 0, int $limit = 50): array
+    public function list(int $offset = 0, int $limit = 50): ?array
     {
         $request = $this->listRequest($offset, $limit);
 
         $json = $this->sendRequest($request);
 
-        return (isset($json['records'])) ? $json['records'] : [];
+        return $json->get('records');
     }
 
     public function query(): QueryBuilder

--- a/src/Clients/WriteClient.php
+++ b/src/Clients/WriteClient.php
@@ -17,30 +17,30 @@ class WriteClient extends ReadClient implements WriteClientInterface
 
     protected Entity $entity;
 
-    public function create(array $values): array
+    public function create(array $values): ?array
     {
         $request = $this->createRequest($values);
 
         $json = $this->sendRequest($request);
 
-        return (isset($json['records']) && isset($json['records'][0])) ? $json['records'][0] : [];
+        return $json->get('records.0');
     }
 
-    public function update(string $identifier, array $values): array
+    public function update(string $identifier, array $values): ?array
     {
         $request = $this->updateRequest($identifier, $values);
 
         $json = $this->sendRequest($request);
 
-        return (isset($json['records']) && isset($json['records'][0])) ? $json['records'][0] : [];
+        return $json->get('records.0');
     }
 
-    public function delete(string $identifier): array
+    public function delete(string $identifier): ?array
     {
         $request = $this->destroyRequest($identifier);
 
         $json = $this->sendRequest($request);
 
-        return (isset($json[0])) ? $json[0] : [];
+        return $json->get('0');
     }
 }

--- a/src/Contracts/QueryBuilder.php
+++ b/src/Contracts/QueryBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tourware\Contracts;
 
+use ArrayAccess;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -49,5 +50,5 @@ interface QueryBuilder
 
     public function total(): int;
 
-    public function get(): array;
+    public function get(): ArrayAccess;
 }

--- a/src/Contracts/ReadClient.php
+++ b/src/Contracts/ReadClient.php
@@ -6,9 +6,9 @@ namespace Tourware\Contracts;
 
 interface ReadClient
 {
-    public function list(int $offset = 0, int $limit = 50): array;
+    public function list(int $offset = 0, int $limit = 50): ?array;
 
-    public function find(string $identifier): array;
+    public function find(string $identifier): ?array;
 
     public function query(): QueryBuilder;
 }

--- a/src/Contracts/WriteClient.php
+++ b/src/Contracts/WriteClient.php
@@ -6,9 +6,9 @@ namespace Tourware\Contracts;
 
 interface WriteClient extends ReadClient
 {
-    public function delete(string $identifier): array;
+    public function delete(string $identifier): ?array;
 
-    public function update(string $identifier, array $values): array;
+    public function update(string $identifier, array $values): ?array;
 
-    public function create(array $values): array;
+    public function create(array $values): ?array;
 }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tourware;
 
+use ArrayAccess;
 use GuzzleHttp\Psr7\Stream;
 use Tourware\Contracts\Entity;
 use Tourware\Contracts\QueryBuilder as QueryBuilderInterface;
@@ -68,7 +69,7 @@ class QueryBuilder implements QueryBuilderInterface
         return $this->sendRequest($request)['total'];
     }
 
-    public function get(): array
+    public function get(): ArrayAccess
     {
         $request = $this->createRequest();
 

--- a/src/Shared/SendRequest.php
+++ b/src/Shared/SendRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tourware\Shared;
 
+use Adbar\Dot;
+use ArrayAccess;
 use Psr\Http\Message\RequestInterface;
 use Tourware\Contracts\Sort as SortInterface;
 use Tourware\Contracts\SortBuilder as SortBuilderInterface;
@@ -14,10 +16,10 @@ trait SendRequest
 {
     protected Http $http;
 
-    protected function sendRequest(RequestInterface $request): array
+    protected function sendRequest(RequestInterface $request): Dot
     {
         $contents = $this->http->sendRequest($request)->getBody()->getContents();
 
-        return json_decode($contents, true);
+        return dot(json_decode($contents, true));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since the PHP version for this plugin is `^7.3` and we can't use 
the nullsafe operator. 

Dot nottation would make the developers life easier.


## Motivation and context

Why is this change required? What problem does it solve?

Since the tourware api returns multiple nested arrays this
PR removes the pain, where the developer always needs to 
check if a array key is set.

Before: 

```php
$json = $client->travel()->query()->get();

return (isset($json['records']) && isset($json['records'][0])) ? $json['records'][0] : [];
```

After:

```php
$json = $client->travel()->query()->get();

$json->get('records.0');
```

