### PR TITLE
List pagination

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,8 @@ jobs:
 
       - name: Execute tests
         continue-on-error: ${{ matrix.php > 8 }}
-        run: vendor/bin/paratest
+        # run: vendor/bin/paratest
+        run: vendor/bin/phpunit
 
       - name: PHPStan
         run: vendor/bin/phpstan analyse --memory-limit=-1 src tests

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ phpcs.xml
 phpunit.xml
 .phpunit.result.cache
 .devcontainer
+
+ray.php
+index.php

--- a/src/Clients/ReadClient.php
+++ b/src/Clients/ReadClient.php
@@ -42,6 +42,8 @@ class ReadClient implements ReadClientInterface
 
         $json = $this->sendRequest($request);
 
+        dd($json);
+
         return $json->get('records');
     }
 

--- a/src/Clients/ReadClient.php
+++ b/src/Clients/ReadClient.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 namespace Tourware\Clients;
 
 use GuzzleHttp\Client as Http;
+use Iterator;
 use Tourware\Contracts\Entity;
 use Tourware\Contracts\QueryBuilder;
 use Tourware\Contracts\ReadClient as ReadClientInterface;
 use Tourware\QueryBuilder as TourwareQueryBuilder;
+use Tourware\Shared\LazyEach;
 use Tourware\Shared\ReadRequests;
 use Tourware\Shared\SendRequest;
 
 class ReadClient implements ReadClientInterface
 {
+    use LazyEach;
     use ReadRequests;
     use SendRequest;
 
@@ -38,13 +41,14 @@ class ReadClient implements ReadClientInterface
 
     public function list(int $offset = 0, int $limit = 50): ?array
     {
-        $request = $this->listRequest($offset, $limit);
+        $res = $this->listAll($offset, $limit);
 
-        $json = $this->sendRequest($request);
+        return iterator_to_array($res, false) ?? null;
+    }
 
-        dd($json);
-
-        return $json->get('records');
+    public function iterator(int $offset = 0, int $limit = 50): Iterator
+    {
+        return $this->listAll($offset, $limit);
     }
 
     public function query(): QueryBuilder

--- a/src/Contracts/QueryBuilder.php
+++ b/src/Contracts/QueryBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tourware\Contracts;
 
 use ArrayAccess;
+use Iterator;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -51,4 +52,7 @@ interface QueryBuilder
     public function total(): int;
 
     public function get(): ArrayAccess;
+
+    public function iterator():Iterator;
+
 }

--- a/src/Shared/LazyEach.php
+++ b/src/Shared/LazyEach.php
@@ -12,9 +12,10 @@ use Psr\Http\Message\RequestInterface;
 
 trait LazyEach
 {
-    protected int $chunk = 300;
+    // protected int $chunk = 300;
+    protected int $chunk = 1;
 
-    abstract protected function listRequest(int $offset, int $limit): RequestInterface;
+    abstract protected function paginatedRequest(int $offset, int $limit): RequestInterface;
 
     abstract protected function sendRequest(RequestInterface $request): Dot;
 
@@ -22,7 +23,7 @@ trait LazyEach
     {
         $page = 1;
 
-        $req = $this->listRequest(
+        $req = $this->paginatedRequest(
             $offset,
             $limit > $this->chunk ? $this->chunk : $limit
         );
@@ -49,7 +50,7 @@ trait LazyEach
 
     protected function listPage(int $page, int $offset, int $limit): Iterator
     {
-        $req = $this->listRequest($offset, $this->chunk);
+        $req = $this->paginatedRequest($offset, $this->chunk);
         $res = $this->sendRequest($req);
 
         $total = ($page - 1) * $this->chunk;

--- a/src/Shared/LazyEach.php
+++ b/src/Shared/LazyEach.php
@@ -1,0 +1,60 @@
+<?php
+
+
+declare(strict_types=1);
+
+namespace Sigmie\Base\Shared;
+
+use Adbar\Dot;
+use Closure;
+use Iterator;
+use Psr\Http\Message\RequestInterface;
+use Sigmie\Base\Actions\Document as DocumentActions;
+use Sigmie\Base\APIs\Count;
+use Sigmie\Base\Documents\Document;
+
+trait LazyEach
+{
+    protected int $chunk = 300;
+
+    abstract protected function listRequest(int $offset, int $limit): RequestInterface;
+
+    abstract protected function sendRequest(RequestInterface $request): Dot;
+
+    protected function listAll(int $offset, int $limit): Iterator
+    {
+        $page = 1;
+
+        $req = $this->listRequest($offset, $limit);
+        $res = $this->sendRequest($req);
+
+        $total = (int) $res['total'];
+
+        foreach ($res['records'] as $record) {
+            yield $record;
+        }
+
+        while ($this->chunk * $page < $total) {
+
+            $page++;
+
+            yield from $this->listPage($page, $offset, $limit);
+        }
+    }
+
+    protected function listPage(int $page, int $offset, int $limit): Iterator
+    {
+        $req = $this->listRequest($offset, $limit);
+        $res = $this->sendRequest($req);
+
+        $body = [
+            'from' => ($page - 1) * $this->chunk,
+            'size' => $this->chunk,
+            'query' => ['match_all' => (object) []]
+        ];
+
+        foreach ($res['records'] as $record) {
+            yield $record;
+        }
+    }
+}

--- a/src/Shared/LazyEach.php
+++ b/src/Shared/LazyEach.php
@@ -12,8 +12,10 @@ use Psr\Http\Message\RequestInterface;
 
 trait LazyEach
 {
-    // protected int $chunk = 300;
-    protected int $chunk = 1;
+    /**
+     * 300 is the Tourware API limit
+     */
+    protected int $chunk = 300;
 
     abstract protected function paginatedRequest(int $offset, int $limit): RequestInterface;
 
@@ -32,7 +34,7 @@ trait LazyEach
 
         $total = (int) $res['total'];
 
-        foreach ($res['records'] as $record) {
+        foreach ($res->get('records', []) as $record) {
             yield $record;
         }
 
@@ -55,7 +57,7 @@ trait LazyEach
 
         $total = ($page - 1) * $this->chunk;
 
-        foreach ($res['records'] as $record) {
+        foreach ($res->get('records', []) as $record) {
 
             if ($total < $limit) {
                 yield $record;

--- a/src/Shared/ReadRequests.php
+++ b/src/Shared/ReadRequests.php
@@ -17,6 +17,7 @@ trait ReadRequests
     {
         self::$stream = $stream;
     }
+
     abstract protected function endpoint(): string;
 
     protected function showRequest(string $identifier): RequestInterface
@@ -26,7 +27,7 @@ trait ReadRequests
         return (is_null(self::$stream)) ? $request : $request->withBody(self::$stream);
     }
 
-    protected function listRequest(int $offset, int $limit): RequestInterface
+    protected function paginatedRequest(int $offset, int $limit): RequestInterface
     {
         $uri = new Uri("{$this->endpoint()}");
         $uri = Uri::withQueryValue($uri, 'limit', (string) $limit);


### PR DESCRIPTION
This PR makes it possible to retrieve more than 300 records using the `list` and the `query` methods.

It uses a generator that iterates 300 records at a time.

The method signatures are kept in place, to keep backwards compability. There was introduces a new method `iterator` which returns an instance of a `Generator` to be used in loops.