### PR TITLE
fix: json_encode body array to prevent error invalid array type in Guzzle request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,9 @@
     "require": {
         "php": "^7.3|^8.0",
         "adbario/php-dot-notation": "^3",
-        "guzzlehttp/guzzle": "^7.3"
-    },
+        "guzzlehttp/guzzle": "^7.3",
+				"ext-json": "*"
+		},
     "require-dev": {
         "brianium/paratest": "^6.3",
         "phpstan/phpstan": "^0.12.90",

--- a/src/Entities/Custom.php
+++ b/src/Entities/Custom.php
@@ -43,7 +43,7 @@ class Custom
             $this->method,
             $this->endpoint,
             [],
-            $this->body
+            is_array($this->body) ? json_encode($this->body) : $this->body
         );
 
         return $this->sendRequest($request, $this->options);


### PR DESCRIPTION
json_ecode body array to prevent error invalid array type in Guzzle request