### PR TITLE
feat: Update SDK domains from Tourware to Flowcore and refresh license ownership metadata.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at `nico@tourware.com`. All
+reported by contacting the project team at `simon@milzer.de`. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.4
 
-LABEL maintainer="Nico"
+LABEL maintainer="Simon Milz"
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright (c) 2020 Nico <nico@tourware.com>
+Copyright (c) 2026 milzer GmbH, Simon Milz <simon@milzer.de>
 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ require 'vendor/autoload.php';
 ```php
 use tourware\Client;
 
-// Create a client for the tourware API (staging by default)
+// Create a client for the flowcore API (staging by default)
 $client = Client::create(
     xApiKey: 'YOUR_X_API_KEY'
 );

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "tourware/sdk-php",
     "type": "library",
-    "description": "PHP SDK for the Tourware API.",
+    "description": "PHP SDK for the flowcore API.",
     "keywords": [
         "tourware",
         "sdk-php"
@@ -10,8 +10,8 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Nico",
-            "email": "nico@tourware.com",
+            "name": "Simon Milz",
+            "email": "simon@milzer.de",
             "role": "Developer"
         }
     ],

--- a/src/Client.php
+++ b/src/Client.php
@@ -27,7 +27,7 @@ class Client
 
     public static function create(string $xApiKey, bool $staging = true)
     {
-        $url = $staging ? 'https://app-staging.tourware.net' : 'https://app.tourware.net';
+        $url = $staging ? 'https://app-staging.flowcore.cloud' : 'https://app.flowcore.cloud';
 
         $auth = new Headers($xApiKey);
         $config = [

--- a/src/Shared/LazyEach.php
+++ b/src/Shared/LazyEach.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\RequestInterface;
 trait LazyEach
 {
     /**
-     * 300 is the Tourware API limit
+     * 300 is the flowcore API limit
      */
     protected int $chunk = 300;
 


### PR DESCRIPTION
## Summary
Update SDK domains from Tourware to Flowcore and refresh license ownership metadata.
## Changes
- `src/Client.php`
  - `app-staging.tourware.net` -> `app-staging.flowcore.cloud`
  - `app.tourware.net` -> `app.flowcore.cloud`
- `LICENSE.md`
  - Updated copyright to:
    `Copyright (c) 2026 milzer GmbH, Simon Milz <simon@milzer.de>`
## Testing
- Verified replacements in code.
- Lint check on edited files passed.
